### PR TITLE
Add Buff ID Search to Monitor Buff Pickers | 监控 Buff 选择器支持按 Buff ID 搜索

### DIFF
--- a/src/lib/config/buff-name-table.ts
+++ b/src/lib/config/buff-name-table.ts
@@ -236,6 +236,20 @@ function getMatchRank(
   return null;
 }
 
+function getIdMatchRank(
+  baseId: number,
+  normalizedKeyword: string,
+): number | null {
+  const normalizedIdKeyword = normalizedKeyword.replace(/^#/, "");
+  if (!/^\d+$/.test(normalizedIdKeyword)) return null;
+
+  const baseIdText = String(baseId);
+  if (baseIdText === normalizedIdKeyword) return 0;
+  if (baseIdText.startsWith(normalizedIdKeyword)) return 2;
+  if (baseIdText.includes(normalizedIdKeyword)) return 5;
+  return null;
+}
+
 export function lookupBuffMeta(
   baseId: number,
   locale = getLocale(),
@@ -343,9 +357,11 @@ export function searchBuffsByName(
 
   for (const meta of getBuffCatalog(locale).metaMap.values()) {
     const alias = normalizedAliases[String(meta.baseId)] ?? null;
+    const idRank = getIdMatchRank(meta.baseId, normalizedKeyword);
     const aliasRank = getMatchRank(alias, normalizedKeyword, 1, 2);
     const defaultRank = getMatchRank(meta.defaultName, normalizedKeyword, 3, 4);
     const rank = Math.min(
+      idRank ?? Number.POSITIVE_INFINITY,
       aliasRank ?? Number.POSITIVE_INFINITY,
       defaultRank ?? Number.POSITIVE_INFINITY,
     );

--- a/src/lib/i18n/messages/en-US.ts
+++ b/src/lib/i18n/messages/en-US.ts
@@ -991,11 +991,11 @@ export const enUSMessages = {
   "skillMonitor.buff.status.aliased": "Alias set",
   "skillMonitor.buff.title": "Buff Monitor",
   "skillMonitor.buff.description":
-    "Search all buffs by name, including icon and text-only buffs",
+    "Search all buffs by name or ID, including icon and text-only buffs",
   "skillMonitor.buff.selectedSummary":
     "Selected buffs {buffCount} / categories {categoryCount}",
-  "skillMonitor.buff.placeholder": "Search buff name",
-  "skillMonitor.buff.searchPrompt": "Enter a keyword to search buffs",
+  "skillMonitor.buff.placeholder": "Search buff name or ID",
+  "skillMonitor.buff.searchPrompt": "Enter a name or ID to search buffs",
   "skillMonitor.buff.selectedTitle": "Selected Buffs",
   "skillMonitor.buff.alias.title": "Buff Alias Settings",
   "skillMonitor.buff.alias.configuredCount": "{count} aliases set",
@@ -1192,9 +1192,9 @@ export const enUSMessages = {
   "monsterMonitor.buffSearch.self": "Search and Add Self-Applied",
   "monsterMonitor.buffSearch.global": "Search and Add Global Monitor",
   "monsterMonitor.buffSearch.placeholderSelf":
-    "Search monster buffs to add as self-applied",
+    "Search monster buffs by name or ID to add as self-applied",
   "monsterMonitor.buffSearch.placeholderGlobal":
-    "Search monster buffs to add to global monitor",
+    "Search monster buffs by name or ID to add to global monitor",
   "monsterMonitor.buffSearch.empty": "No matching monster buffs",
   "monsterMonitor.buffSearch.status.addedGlobal": "Added globally",
   "monsterMonitor.buffSearch.status.currentSelf": "Currently self-applied",
@@ -1215,7 +1215,8 @@ export const enUSMessages = {
   "monsterMonitor.buffGroups.removeTitle": "Click to remove",
   "monsterMonitor.buffGroups.empty": "No buffs selected",
   "monsterMonitor.teammate.title": "Teammate Buff Monitor",
-  "monsterMonitor.teammate.placeholder": "Search and add teammate buffs",
+  "monsterMonitor.teammate.placeholder":
+    "Search teammate buffs by name or ID",
   "monsterMonitor.teammate.emptySearch": "No matching teammate buffs",
   "monsterMonitor.teammate.groupTitle": "Monitored Teammate Buffs",
   "monsterMonitor.teammate.styleTitle": "Teammate Buff Matrix Style",

--- a/src/lib/i18n/messages/ja-JP.ts
+++ b/src/lib/i18n/messages/ja-JP.ts
@@ -973,11 +973,11 @@ export const jaJPMessages = {
   "skillMonitor.buff.status.aliased": "別名設定済み",
   "skillMonitor.buff.title": "Buff モニター",
   "skillMonitor.buff.description":
-    "アイコン付き/テキストのみの Buff を含め、名前ですべての Buff を検索",
+    "アイコン付き/テキストのみの Buff を含め、名前または ID ですべての Buff を検索",
   "skillMonitor.buff.selectedSummary":
     "選択 Buff {buffCount} / カテゴリ {categoryCount}",
-  "skillMonitor.buff.placeholder": "Buff 名を検索",
-  "skillMonitor.buff.searchPrompt": "キーワードを入力して Buff を検索",
+  "skillMonitor.buff.placeholder": "Buff 名または ID を検索",
+  "skillMonitor.buff.searchPrompt": "名前または ID を入力して Buff を検索",
   "skillMonitor.buff.selectedTitle": "選択した Buff",
   "skillMonitor.buff.alias.title": "Buff 別名設定",
   "skillMonitor.buff.alias.configuredCount": "{count} 件の別名を設定",
@@ -1177,9 +1177,9 @@ export const jaJPMessages = {
   "monsterMonitor.buffSearch.self": "検索して自己付与を追加",
   "monsterMonitor.buffSearch.global": "検索してグローバルモニターを追加",
   "monsterMonitor.buffSearch.placeholderSelf":
-    "自己付与として追加するモンスター Buff を検索",
+    "自己付与として追加するモンスター Buff を名前または ID で検索",
   "monsterMonitor.buffSearch.placeholderGlobal":
-    "グローバルモニターに追加するモンスター Buff を検索",
+    "グローバルモニターに追加するモンスター Buff を名前または ID で検索",
   "monsterMonitor.buffSearch.empty": "一致するモンスター Buff がありません",
   "monsterMonitor.buffSearch.status.addedGlobal": "グローバルに追加済み",
   "monsterMonitor.buffSearch.status.currentSelf": "現在は自己付与",
@@ -1200,7 +1200,7 @@ export const jaJPMessages = {
   "monsterMonitor.buffGroups.removeTitle": "クリックで削除",
   "monsterMonitor.buffGroups.empty": "Buff が選択されていません",
   "monsterMonitor.teammate.title": "味方 Buff モニター",
-  "monsterMonitor.teammate.placeholder": "味方 Buff を検索して追加",
+  "monsterMonitor.teammate.placeholder": "味方 Buff を名前または ID で検索",
   "monsterMonitor.teammate.emptySearch": "一致する味方 Buff がありません",
   "monsterMonitor.teammate.groupTitle": "モニター中の味方 Buff",
   "monsterMonitor.teammate.styleTitle": "味方 Buff マトリクススタイル",

--- a/src/lib/i18n/messages/zh-CN.ts
+++ b/src/lib/i18n/messages/zh-CN.ts
@@ -893,11 +893,11 @@ export const zhCNMessages = {
   "skillMonitor.buff.status.aliased": "已设别名",
   "skillMonitor.buff.title": "Buff 监控",
   "skillMonitor.buff.description":
-    "统一通过 Buff 名称搜索（含有图标/无图标 Buff）",
+    "统一通过 Buff 名称或 ID 搜索（含有图标/无图标 Buff）",
   "skillMonitor.buff.selectedSummary":
     "已选 Buff {buffCount} / 分类 {categoryCount}",
-  "skillMonitor.buff.placeholder": "搜索 Buff 名称",
-  "skillMonitor.buff.searchPrompt": "请输入关键词搜索 Buff",
+  "skillMonitor.buff.placeholder": "搜索 Buff 名称或 ID",
+  "skillMonitor.buff.searchPrompt": "请输入名称或 ID 搜索 Buff",
   "skillMonitor.buff.selectedTitle": "已选 Buff",
   "skillMonitor.buff.alias.title": "Buff 别名设置",
   "skillMonitor.buff.alias.configuredCount": "已设置别名 {count}",
@@ -1084,9 +1084,9 @@ export const zhCNMessages = {
   "monsterMonitor.buffSearch.self": "搜索加入仅自身施加",
   "monsterMonitor.buffSearch.global": "搜索加入全局监控",
   "monsterMonitor.buffSearch.placeholderSelf":
-    "搜索要加入仅自身施加的 Boss Buff",
+    "按名称或 ID 搜索要加入仅自身施加的 Boss Buff",
   "monsterMonitor.buffSearch.placeholderGlobal":
-    "搜索要加入全局监控的 Boss Buff",
+    "按名称或 ID 搜索要加入全局监控的 Boss Buff",
   "monsterMonitor.buffSearch.empty": "没有匹配的 Boss Buff",
   "monsterMonitor.buffSearch.status.addedGlobal": "已加全局",
   "monsterMonitor.buffSearch.status.currentSelf": "当前在仅自身",
@@ -1107,7 +1107,7 @@ export const zhCNMessages = {
   "monsterMonitor.buffGroups.removeTitle": "点击移除",
   "monsterMonitor.buffGroups.empty": "尚未选择 Buff",
   "monsterMonitor.teammate.title": "队友 Buff 监控",
-  "monsterMonitor.teammate.placeholder": "搜索并添加队友 Buff",
+  "monsterMonitor.teammate.placeholder": "按名称或 ID 搜索队友 Buff",
   "monsterMonitor.teammate.emptySearch": "没有匹配的队友 Buff",
   "monsterMonitor.teammate.groupTitle": "已监控队友 Buff",
   "monsterMonitor.teammate.styleTitle": "队友 Buff 矩阵样式",


### PR DESCRIPTION
Added buff ID search support for both Live Monitor and Monster Monitor. Buff searches now match by alias, default name, or numeric buff ID, with exact ID matches ranked first, then prefix and partial ID matches. Updated Live Monitor and Monster Monitor search placeholder/help text in EN, zh-CN, and ja-JP to indicate buffs can be searched by name or ID.

Verification: npm run build passes.

为实时监控和怪物监控新增了 Buff ID 搜索支持。现在 Buff 搜索会同时匹配别名、默认名称和数字 Buff ID，其中完整 ID 匹配优先，其次是 ID 前缀匹配和部分匹配。同步更新了实时监控与怪物监控的搜索占位/提示文案，说明可通过名称或 ID 搜索 Buff，并覆盖 EN、zh-CN、ja-JP 文案。

验证：npm run build 通过。